### PR TITLE
Remove `initial` input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/caarlos0/svu:v1.8.0
+FROM ghcr.io/caarlos0/svu:v1.9.0
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ Defaults to `next`, but also supports: `major`, `minor` or `patch`.
 
 **Optional**: Invokes `svu --prefix`'s behaviour, defaults to `v`.
 
-## `initial`
-
-If this is not set, the action will fail if the current version cannot be determined.
-Otherwise this SemVer will be used as the initial version.
-
 ## Outputs
 
 ## `version`
@@ -40,15 +35,6 @@ with:
   bump: 'next'
 ```
 
-## Set an initial version
-
-```yaml
-uses: jsok/svu-version-bump-action@v1
-with:
-  bump: 'next'
-  initial: '0.0.1'
-```
-
 ## Custom pattern and prefix
 
 ```yaml
@@ -57,5 +43,4 @@ with:
   bump: 'next'
   pattern: 'foo/*'
   prefix: 'foo/v'
-  initial: '0.0.1'
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,6 @@ inputs:
     description: 'Tag prefix'
     required: false
     default: 'v'
-  initial:
-    description: 'Initial version to set if the current version cannot be found'
-    required: false
 outputs:
   version:
     description: 'Next version'
@@ -28,4 +25,3 @@ runs:
     - ${{ inputs.bump }}
     - ${{ inputs.pattern }}
     - ${{ inputs.prefix }}
-    - ${{ inputs.initial }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,22 +5,14 @@ set -eu
 BUMP=$1
 PATTERN=$2
 PREFIX=$3
-INITIAL=${4:-}
 
 if svu --pattern="${PATTERN}" --prefix="${PREFIX}" current 2>/dev/null 1>/dev/null
 then
     version="$(svu --pattern="${PATTERN}" --prefix="${PREFIX}" "${BUMP}")"
     version_without_prefix="$(svu --pattern="${PATTERN}" --prefix="${PREFIX}" --strip-prefix "${BUMP}")"
 else
-    if [ -n "${INITIAL}" ]
-    then
-        echo "::warning Could not find a current version, initialising version to ${INITIAL}"
-        version="${PREFIX}${INITIAL}"
-        version_without_prefix="${INITIAL}"
-    else
-        echo "::error Could not find a current version!"
-        exit 1
-    fi
+    echo "::error Could not find a current version!"
+    exit 1
 fi
 echo "::group::Next version"
 echo "${version}"


### PR DESCRIPTION
This is a breaking change.
svu v1.9.0 now [assumes an initial version of 0.0.0][0-ver], so rely on
that functionality instead.
Removing `initial` also means you cannot start at a version other than
0.0.0 either.

[0-ver]: https://github.com/caarlos0/svu/pull/43
